### PR TITLE
Fix long URL wrapping issue #5

### DIFF
--- a/web/css/app.css
+++ b/web/css/app.css
@@ -6,6 +6,10 @@ body {
     display: none;
 }
 
+.results-box .list-group-item {
+    overflow-wrap: break-word;
+}
+
 input#derefUrl {
     margin-bottom: 16px;
 }


### PR DESCRIPTION
Fixes issue #5 by adding an overflow-wrap of "break-word".

Unfortunately I can't deploy this just yet because the FE ecosystem has decayed over time and I may need to rebuild the support structures for it. Or maybe I can use unpkg - not sure yet.